### PR TITLE
Add filter_qa support in test-targets

### DIFF
--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -47,6 +47,8 @@ object TestFilters {
     private const val ARGUMENT_TEST_FILE = "testFile"
     private const val ARGUMENT_NOT_TEST_FILE = "notTestFile"
 
+    private const val ARGUMENT_ONLY_QA = "filter_qa"
+
     private val FILTER_ARGUMENT by lazy {
 
         val pattern = listOf(
@@ -58,7 +60,8 @@ object TestFilters {
             ARGUMENT_TEST_PACKAGE,
             ARGUMENT_NOT_TEST_PACKAGE,
             ARGUMENT_TEST_FILE,
-            ARGUMENT_NOT_TEST_FILE
+            ARGUMENT_NOT_TEST_FILE,
+            ARGUMENT_ONLY_QA
         ).joinToString("|")
 
         Pattern.compile("""($pattern)\s+(.+)""")
@@ -114,6 +117,7 @@ object TestFilters {
             ARGUMENT_TEST_FILE -> fromTestFile(args)
             ARGUMENT_NOT_TEST_FILE -> not(fromTestFile(args))
             ARGUMENT_TEST_SIZE -> withSize(args)
+            ARGUMENT_ONLY_QA -> onlyQA()
             else -> throw FlankConfigurationError("Filtering option $command not supported")
         }
     }
@@ -180,6 +184,15 @@ object TestFilters {
             testMethod.annotationNames.any { annotations.contains(it) }
         },
         isAnnotation = true
+    )
+
+    private fun onlyQA(): TestFilter = TestFilter(
+        describe = "onlyQA",
+        shouldRun = { testMethod ->
+            val className = testMethod.testName.split("#").first()
+            val simpleName = className.split(".").last()
+            simpleName.startsWith("QA") && simpleName.endsWith("Test")
+        }
     )
 
     private fun not(filter: TestFilter): TestFilter = TestFilter(

--- a/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
@@ -31,6 +31,8 @@ val WITH_SMALL_ANNOTATION =
 val WITHOUT_LARGE_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
 val WITHOUT_MEDIUM_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
 val WITHOUT_SMALL_ANNOTATION = TestMethod("whatever.Foo#testName", emptyList())
+val QA_TEST = TestMethod("whatever.QAIntroTest", emptyList())
+val NON_QA_TEST = TestMethod("whatever.IntroTest", emptyList())
 const val TEST_FILE = "src/test/kotlin/ftl/filter/fixtures/dummy-tests-file.txt"
 const val TEST_FILE_2 = "src/test/kotlin/ftl/filter/fixtures/exclude-tests.txt"
 private const val IGNORE_ANNOTATION = "org.junit.Ignore"
@@ -131,6 +133,14 @@ class TestFiltersTest {
         assertThat(filter.shouldRun(WITH_FOO_ANNOTATION)).isTrue()
         assertThat(filter.shouldRun(WITH_BAR_ANNOTATION)).isTrue()
         assertThat(filter.shouldRun(WITHOUT_FOO_ANNOTATION)).isFalse()
+    }
+
+    @Test
+    fun testFilteringOnlyQA() {
+        val filter = fromTestTargets(listOf("filter_qa true"))
+
+        assertThat(filter.shouldRun(QA_TEST)).isTrue()
+        assertThat(filter.shouldRun(NON_QA_TEST)).isFalse()
     }
 
     @Test


### PR DESCRIPTION
Replay of #1 with an updated master...

It would be nice to introduce a regex based rule in order to not have Mercari specific logic.